### PR TITLE
Fix name space

### DIFF
--- a/R/vario.R
+++ b/R/vario.R
@@ -321,7 +321,7 @@ vario_map<-function(db,vname,gridRes=20){
 model_fit<-function(vario,polDrift=NULL,extDrift=NULL,struct="SPHERICAL",pruneModel=TRUE,anisoModel=TRUE){
   types = .checkStructNames(struct)
   model = Model()
-  if(class(vario)=="_p_Vario"){
+  if(class(vario)=="_p_gstlrn__Vario"){
     
     if (!is.null(extDrift) || !is.null(polDrift)){
       ## Add drifts to model
@@ -329,7 +329,7 @@ model_fit<-function(vario,polDrift=NULL,extDrift=NULL,struct="SPHERICAL",pruneMo
     } 
     err = model$fit(vario, types=types, optvar=Option_VarioFit(flag_noreduce=pruneModel,auth_aniso=anisoModel))
   
-  }else if(class(vario)=="_p_DbGrid"){
+  }else if(class(vario)=="_p_gstlrn__DbGrid"){
     vn=vario$getNames("VMAP.*.Var")[1]
     if(is.na(vn)){
       stop("The DbGrid supplied in 'vario' should contain a variogram map saved as a variable whose name is of the form 'VMAP.*.Var'.")

--- a/TP/01_gstlearn_start.Rmd
+++ b/TP/01_gstlearn_start.Rmd
@@ -43,7 +43,7 @@ base::message("Erreur dans validObject(.Object) :
 
 * If you need to duplicate your objects, a simple assignment (e.g. `db2 = db1`) is not possible. You must use the `clone` method by doing this: `db2 = db1$clone()`. (Otherwise you would just copy the pointer to the object)
 
-* If you ask for the class type of a gstlearn object under R (e.g. class(mygrid)), you will obtain the C++ class name prefixed with ‘p’ (e.g. _p_DbGrid).
+* If you ask for the class type of a gstlearn object under R (e.g. class(mygrid)), you will obtain the C++ class name prefixed with ‘p’ (e.g. _p_gstlrn__DbGrid).
 		
 
 * The *gstlearn* objects memory content is not stored in the R workspace anymore. This means that saving the R workspace (`.RData`) is dangerous because it stores only memory pointers that won't be valid when loading the workspace in a future R session.


### PR DESCRIPTION
Now (dev branch) almost all **gstlearn** classes are included in a C++ namespace named `gstlrn`
Now, SWIG exposes these classes in R and python using a new decorated name. Example:

- Old: `_p_Vario`
- New: `_p_gstlrn__Vario`

The source code for **minigst** has been updated consequently